### PR TITLE
Threaded replies: vendored chat_thread_lib (:core:chat-thread) + nested reply-to-reply

### DIFF
--- a/core/chat-thread/README.md
+++ b/core/chat-thread/README.md
@@ -1,0 +1,27 @@
+# :core:chat-thread — vendored CollapsibleChatThread
+
+This module is a **verbatim vendor** of the `chatthread` library module from
+[extractive-mana-pulse/chat_thread_lib](https://github.com/extractive-mana-pulse/chat_thread_lib)
+(package `com.example.chatthread`, same public API).
+
+**Why vendored instead of the JitPack dependency:** the published artifact
+(`com.github.extractive-mana-pulse:chatthread`) is an Android-only AAR, but this project's
+feature UI lives in KMP `commonMain` (Android / iOS / Desktop). The library source is pure
+Compose (no Android imports), so compiling it in `commonMain` makes it usable on every platform.
+
+- `src/commonMain/.../chatthread/*` — byte-identical copies of the upstream sources. **Do not
+  edit them here**; change upstream and re-copy, so the two stay diffable.
+- `src/commonTest/.../ThreadFlattenerTest.kt` — the upstream JUnit4 test ported to `kotlin.test`
+  (same cases, multiplatform runner).
+
+To sync with upstream:
+
+```sh
+git clone https://github.com/extractive-mana-pulse/chat_thread_lib /tmp/ctl
+cp /tmp/ctl/chatthread/src/main/java/com/example/chatthread/*.kt \
+   core/chat-thread/src/commonMain/kotlin/com/example/chatthread/
+cp /tmp/ctl/chatthread/src/main/java/com/example/chatthread/internal/*.kt \
+   core/chat-thread/src/commonMain/kotlin/com/example/chatthread/internal/
+```
+
+Used by `:feature:tweet:presentation` to render the tweet-detail reply thread.

--- a/core/chat-thread/build.gradle.kts
+++ b/core/chat-thread/build.gradle.kts
@@ -7,14 +7,16 @@ plugins {
     alias(libs.plugins.composeCompiler)
 }
 
-// Tweet feature — presentation layer: shared TweetItem, feed + post-tweet MVI, Koin module.
+// CollapsibleChatThread — github.com/extractive-mana-pulse/chat_thread_lib vendored verbatim
+// (see README.md in this module). The upstream JitPack artifact is an Android-only AAR, so the
+// pure-Compose source is compiled here as commonMain to serve Android + iOS + Desktop alike.
 kotlin {
     iosArm64()
     iosSimulatorArm64()
     jvm()
 
     androidLibrary {
-        namespace = "com.example.twitturin.feature.tweet.presentation"
+        namespace = "com.example.chatthread"
         compileSdk = libs.versions.android.compileSdk.get().toInt()
         minSdk = libs.versions.android.minSdk.get().toInt()
 
@@ -25,16 +27,7 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            api(projects.feature.tweet.domain)
-            implementation(projects.core.domain)
-            implementation(projects.core.presentation)
-            implementation(projects.core.designSystem)
-            implementation(projects.core.chatThread)
             implementation(libs.bundles.compose)
-            implementation(libs.bundles.lifecycleCompose)
-            implementation(libs.bundles.koinCompose)
-            implementation(libs.bundles.coil)
-            implementation(libs.kotlinx.coroutines.core)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/core/chat-thread/src/commonMain/kotlin/com/example/chatthread/CollapsibleChatThread.kt
+++ b/core/chat-thread/src/commonMain/kotlin/com/example/chatthread/CollapsibleChatThread.kt
@@ -1,0 +1,137 @@
+package com.example.chatthread
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.example.chatthread.internal.CommentRow
+import com.example.chatthread.internal.flattenThread
+
+/**
+ * Holder for the set of currently-expanded comment ids.
+ *
+ * Hoisted state: create this once via [rememberThreadState] and pass it into
+ * [CollapsibleChatThread]. Keeping expansion outside of the composable lets you drive it from
+ * outside (e.g. expand-all buttons, deep links) and survives configuration changes via the
+ * companion [Saver].
+ *
+ * The state is intentionally a `Set<String>` of ids rather than a tree-shaped structure: the
+ * flattener consults it per-row, so collapsing an ancestor automatically hides descendants even if
+ * the descendants are still in [expandedIds]. That means you never have to walk the tree to
+ * "clean up" child ids when a parent collapses.
+ */
+@Stable
+class ThreadState internal constructor(initial: Set<String>) {
+    /** Ids of every comment whose replies should be visible. Mutated via [toggle]/[expand]/[collapse]. */
+    var expandedIds: Set<String> by mutableStateOf(initial)
+        internal set
+
+    /** Returns true if the comment with [id] is currently expanded. */
+    fun isExpanded(id: String): Boolean = id in expandedIds
+
+    /** Flip the expanded state for [id]. */
+    fun toggle(id: String) {
+        expandedIds = if (id in expandedIds) expandedIds - id else expandedIds + id
+    }
+
+    /** Mark [id] as expanded (no-op if already expanded). */
+    fun expand(id: String) {
+        if (id !in expandedIds) expandedIds = expandedIds + id
+    }
+
+    /** Mark [id] as collapsed (no-op if already collapsed). */
+    fun collapse(id: String) {
+        if (id in expandedIds) expandedIds = expandedIds - id
+    }
+
+    companion object {
+        /**
+         * Saves [expandedIds] as a `List<String>` so expansion survives configuration changes
+         * (rotation, process death) when wrapped by [rememberSaveable].
+         */
+        val Saver: Saver<ThreadState, List<String>> = Saver(
+            save = { it.expandedIds.toList() },
+            restore = { ThreadState(it.toSet()) },
+        )
+    }
+}
+
+/**
+ * Creates (or restores) a [ThreadState] that survives configuration changes.
+ *
+ * @param initiallyExpanded Ids to expand on first composition. Typical usage: pass the root
+ *   comment id so the thread opens up by default.
+ */
+@Composable
+fun rememberThreadState(
+    initiallyExpanded: Set<String> = emptySet(),
+): ThreadState = rememberSaveable(saver = ThreadState.Saver) {
+    ThreadState(initiallyExpanded)
+}
+
+/**
+ * Renders a scrollable, collapsible, infinitely-nestable comment thread.
+ *
+ * The composable flattens the incoming [comments] tree into a depth-annotated row list and feeds
+ * that list into a [LazyColumn], so the cost scales with what is currently *visible*, not with the
+ * total tree size. Each row draws its own connector lines (trunks, tees, rounded-L's) via a custom
+ * `Modifier`, which means rows are self-contained — they never measure their siblings or parent.
+ *
+ * Example:
+ * ```
+ * val state = rememberThreadState(initiallyExpanded = setOf(rootId))
+ * CollapsibleChatThread(
+ *     comments = myComments,
+ *     state = state,
+ *     style = ThreadStyle.Default.copy(
+ *         expandIcon = { painterResource(R.drawable.plus) },
+ *         collapseIcon = { painterResource(R.drawable.minus) },
+ *         replyIcon = { painterResource(R.drawable.reply) },
+ *     ),
+ *     onReplyClick = { comment -> /* open composer */ },
+ * )
+ * ```
+ *
+ * @param comments Root comments. Each may carry any depth of [ThreadComment.replies].
+ * @param modifier Outer modifier applied to the backing [LazyColumn].
+ * @param style Visual configuration; use [ThreadStyle.Default] or `.copy(...)` it.
+ * @param state Hoisted expansion state. Defaults to a fresh empty state from [rememberThreadState].
+ * @param contentPadding Forwarded to [LazyColumn] — use this to pad around system bars, FABs, etc.
+ * @param onReplyClick Invoked when a row's "Reply" action is tapped. The tapped [ThreadComment] is
+ *   passed in so the caller can open a composer scoped to that comment.
+ */
+@Composable
+fun CollapsibleChatThread(
+    comments: List<ThreadComment>,
+    modifier: Modifier = Modifier,
+    style: ThreadStyle = ThreadStyle.Default,
+    state: ThreadState = rememberThreadState(),
+    contentPadding: PaddingValues = PaddingValues(0.dp),
+    onReplyClick: (ThreadComment) -> Unit = {},
+) {
+    val visibleRows = remember(comments, state.expandedIds) {
+        flattenThread(comments, state.expandedIds)
+    }
+    LazyColumn(modifier = modifier, contentPadding = contentPadding) {
+        items(
+            items = visibleRows,
+            key = { row -> row.comment.id + ":" + row.depth },
+        ) { row ->
+            CommentRow(
+                row = row,
+                style = style,
+                onToggle = { state.toggle(row.comment.id) },
+                onReplyClick = onReplyClick,
+            )
+        }
+    }
+}

--- a/core/chat-thread/src/commonMain/kotlin/com/example/chatthread/ThreadComment.kt
+++ b/core/chat-thread/src/commonMain/kotlin/com/example/chatthread/ThreadComment.kt
@@ -1,0 +1,56 @@
+package com.example.chatthread
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.graphics.Color
+
+/**
+ * A single comment in a collapsible chat thread.
+ *
+ * The tree is formed by [replies]: each child is itself a [ThreadComment] and may hold its own
+ * replies to any depth. The library does not care where the data comes from — build the tree from
+ * a network response, a database, or a hard-coded demo list.
+ *
+ * [id] must be unique across the whole tree. It is used as the LazyColumn item key and as the key
+ * into [ThreadState.expandedIds], so two rows with the same id will confuse state and animations.
+ *
+ * [avatarInitial] defaults to the first character of [author]; override it if you want something
+ * else (e.g. emoji, a two-letter pair, or a localized initial).
+ *
+ * @property id Stable unique identifier for this comment.
+ * @property author Display name shown on the header line.
+ * @property avatarBackground Background color of the circular avatar.
+ * @property timestamp Free-form time string — the library does not format it.
+ * @property body Main comment text.
+ * @property avatarInitial Character(s) rendered inside the avatar circle.
+ * @property channel Optional secondary line under the author (e.g. a category tag).
+ * @property title Optional bold title above the body (used for the root post in the demo).
+ * @property tags Optional list of small colored badges shown above the title/body.
+ * @property replies Nested replies. Empty means this is a leaf.
+ */
+@Immutable
+data class ThreadComment(
+    val id: String,
+    val author: String,
+    val avatarBackground: Color,
+    val timestamp: String,
+    val body: String,
+    val avatarInitial: String = author.firstOrNull()?.toString().orEmpty(),
+    val channel: String? = null,
+    val title: String? = null,
+    val tags: List<ThreadTag> = emptyList(),
+    val replies: List<ThreadComment> = emptyList(),
+)
+
+/**
+ * A small colored badge shown next to the comment's author line.
+ *
+ * @property text Label text displayed inside the badge.
+ * @property background Pill background color.
+ * @property contentColor Text color drawn on top of [background].
+ */
+@Immutable
+data class ThreadTag(
+    val text: String,
+    val background: Color,
+    val contentColor: Color,
+)

--- a/core/chat-thread/src/commonMain/kotlin/com/example/chatthread/ThreadStyle.kt
+++ b/core/chat-thread/src/commonMain/kotlin/com/example/chatthread/ThreadStyle.kt
@@ -1,0 +1,121 @@
+package com.example.chatthread
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+
+/**
+ * Visual configuration for [CollapsibleChatThread].
+ *
+ * Every dimension, color, text style, and icon the thread draws is sourced from this data class,
+ * so a single `ThreadStyle.Default.copy(...)` is enough to re-skin the whole component. Dimensions
+ * are used both for layout *and* for connector math, so changing [avatarSize] or [indentPerLevel]
+ * keeps the tree lines aligned automatically — no magic numbers baked into the drawing code.
+ *
+ * Icons are exposed as `@Composable () -> Painter?` lambdas so the library stays free of Android
+ * resource dependencies: callers pass `painterResource(R.drawable.foo)` (or return `null` to draw
+ * a text-only chip).
+ *
+ * @property avatarSize Diameter of the circular avatar; also drives connector column positions.
+ * @property avatarContentColor Text color for the avatar's initial character.
+ * @property connectorColor Color used for every tree line (vertical trunks, horizontal branches, rounded L's).
+ * @property connectorStrokeWidth Stroke width of tree lines.
+ * @property connectorCornerRadius Corner rounding for the "last sibling" L-connector; clamped to the avatar radius.
+ * @property indentPerLevel Horizontal indent added per nesting level; also drives trunk column spacing.
+ * @property rowVerticalSpacing Space below each row, reserved inside the row so drawn connectors can span it.
+ * @property avatarToContentSpacing Gap between the avatar and the text column.
+ * @property contentPaddingEnd Right-side padding for the text column.
+ * @property contentVerticalGap Base vertical gap used between text blocks, tag padding, and action icon spacing.
+ * @property primaryTextColor Color for author name, title, body.
+ * @property secondaryTextColor Color for timestamp, channel, and body.
+ * @property replyText Label for the reply action (localize here).
+ * @property authorStyle Typography for the author name.
+ * @property timestampStyle Typography for the timestamp fragment on the author line.
+ * @property channelStyle Typography for the optional channel/category line.
+ * @property tagStyle Typography for badge text inside [ThreadTag] pills.
+ * @property titleStyle Typography for [ThreadComment.title].
+ * @property bodyStyle Typography for [ThreadComment.body].
+ * @property actionStyle Typography for the "Show N replies" / "Reply" buttons.
+ * @property avatarTextStyle Typography for the single initial rendered inside the avatar.
+ * @property expandIcon Painter for the "expand" affordance on collapsible rows. Return `null` for text-only.
+ * @property collapseIcon Painter shown while a row is expanded.
+ * @property replyIcon Painter for the reply action.
+ */
+@Immutable
+data class ThreadStyle(
+    val avatarSize: Dp = 28.dp,
+    val avatarContentColor: Color = Color(0xFF0F0F18),
+    val connectorColor: Color = Color.White.copy(alpha = 0.3f),
+    val connectorStrokeWidth: Dp = 2.dp,
+    val connectorCornerRadius: Dp = 12.dp,
+    val indentPerLevel: Dp = 28.dp,
+    val rowVerticalSpacing: Dp = 16.dp,
+    val avatarToContentSpacing: Dp = 12.dp,
+    val contentPaddingEnd: Dp = 16.dp,
+    val contentVerticalGap: Dp = 6.dp,
+    val primaryTextColor: Color = Color.White,
+    val secondaryTextColor: Color = Color(0xFFAFB2B9),
+    val replyText: String = "Reply",
+    val authorStyle: TextStyle = TextStyle(
+        fontSize = 15.sp,
+        lineHeight = 20.sp,
+        letterSpacing = 0.1.sp,
+        fontWeight = FontWeight.W600,
+    ),
+    val timestampStyle: TextStyle = TextStyle(
+        fontSize = 12.sp,
+        lineHeight = 16.sp,
+        letterSpacing = 0.1.sp,
+        fontWeight = FontWeight.W500,
+    ),
+    val channelStyle: TextStyle = TextStyle(
+        fontSize = 10.sp,
+        lineHeight = 12.sp,
+        letterSpacing = 0.1.sp,
+        fontWeight = FontWeight.W500,
+    ),
+    val tagStyle: TextStyle = TextStyle(
+        fontSize = 10.sp,
+        lineHeight = 12.sp,
+        letterSpacing = 0.1.sp,
+        fontWeight = FontWeight.W500,
+    ),
+    val titleStyle: TextStyle = TextStyle(
+        fontSize = 20.sp,
+        lineHeight = 26.sp,
+        letterSpacing = 0.5.sp,
+        fontWeight = FontWeight.W700,
+    ),
+    val bodyStyle: TextStyle = TextStyle(
+        fontSize = 15.sp,
+        lineHeight = 20.sp,
+        letterSpacing = 0.1.sp,
+        fontWeight = FontWeight.W400,
+    ),
+    val actionStyle: TextStyle = TextStyle(
+        fontSize = 15.sp,
+        lineHeight = 20.sp,
+        letterSpacing = 0.1.sp,
+        fontWeight = FontWeight.W500,
+    ),
+    val avatarTextStyle: TextStyle = TextStyle(
+        fontSize = 14.sp,
+        lineHeight = 14.sp,
+        letterSpacing = 0.sp,
+        fontWeight = FontWeight.W700,
+    ),
+    val expandIcon: @Composable () -> Painter? = { null },
+    val collapseIcon: @Composable () -> Painter? = { null },
+    val replyIcon: @Composable () -> Painter? = { null },
+) {
+    companion object {
+        /** Library defaults — dark-theme friendly. Use `ThreadStyle.Default.copy(...)` to tweak. */
+        val Default = ThreadStyle()
+    }
+}

--- a/core/chat-thread/src/commonMain/kotlin/com/example/chatthread/internal/CommentRow.kt
+++ b/core/chat-thread/src/commonMain/kotlin/com/example/chatthread/internal/CommentRow.kt
@@ -1,0 +1,282 @@
+package com.example.chatthread.internal
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.withStyle
+import com.example.chatthread.ThreadComment
+import com.example.chatthread.ThreadStyle
+import com.example.chatthread.ThreadTag
+
+/**
+ * Renders a single visible row inside [com.example.chatthread.CollapsibleChatThread].
+ *
+ * The outer [Box] applies [threadConnectors] so the tree lines are drawn *behind* the row's
+ * content, and reserves [ThreadStyle.rowVerticalSpacing] at the bottom — this padding is inside
+ * the row so the connector's own trunk can span it without jumping across a gap to the next row.
+ *
+ * The inner [Row] is indented by `indentPerLevel * depth`, which places the avatar exactly at the
+ * x-coordinate the connector math assumes.
+ *
+ * @param row Flattened metadata and payload for this row.
+ * @param style Shared visual configuration.
+ * @param onToggle Invoked when the user taps the expand/collapse chip.
+ * @param onReplyClick Invoked when the user taps the reply chip; receives the row's comment.
+ */
+@Composable
+internal fun CommentRow(
+    row: VisibleRow,
+    style: ThreadStyle,
+    onToggle: () -> Unit,
+    onReplyClick: (ThreadComment) -> Unit,
+) {
+    val comment = row.comment
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .threadConnectors(
+                depth = row.depth,
+                ancestorHasMoreSiblings = row.ancestorHasMoreSiblings,
+                isLastSiblingAtDepth = row.isLastSiblingAtDepth,
+                isExpanded = row.isExpanded,
+                avatarSize = style.avatarSize,
+                indentPerLevel = style.indentPerLevel,
+                cornerRadius = style.connectorCornerRadius,
+                strokeWidth = style.connectorStrokeWidth,
+                color = style.connectorColor,
+            )
+            .padding(bottom = style.rowVerticalSpacing)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = style.indentPerLevel * row.depth),
+            verticalAlignment = Alignment.Top,
+        ) {
+            Avatar(
+                initial = comment.avatarInitial,
+                background = comment.avatarBackground,
+                style = style,
+            )
+            Spacer(Modifier.width(style.avatarToContentSpacing))
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(end = style.contentPaddingEnd),
+            ) {
+                AuthorLine(comment = comment, style = style)
+                if (comment.tags.isNotEmpty()) {
+                    Spacer(Modifier.height(style.contentVerticalGap))
+                    TagRow(tags = comment.tags, style = style)
+                }
+                if (!comment.title.isNullOrEmpty()) {
+                    Spacer(Modifier.height(style.contentVerticalGap))
+                    Text(
+                        text = comment.title,
+                        style = style.titleStyle.copy(color = style.primaryTextColor),
+                    )
+                }
+                Spacer(Modifier.height(style.contentVerticalGap))
+                Text(
+                    text = comment.body,
+                    style = style.bodyStyle.copy(color = style.secondaryTextColor),
+                )
+                Spacer(Modifier.height(style.contentVerticalGap))
+                ActionRow(
+                    row = row,
+                    style = style,
+                    onToggle = onToggle,
+                    onReplyClick = { onReplyClick(comment) },
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Circular avatar with a single centered initial character.
+ *
+ * Sized to [ThreadStyle.avatarSize] so the connector math (which derives its column positions from
+ * the same value) lines up with the avatar's visual center.
+ */
+@Composable
+private fun Avatar(
+    initial: String,
+    background: Color,
+    style: ThreadStyle,
+) {
+    Text(
+        text = initial,
+        style = style.avatarTextStyle.copy(
+            color = style.avatarContentColor,
+            textAlign = TextAlign.Center,
+        ),
+        modifier = Modifier
+            .size(style.avatarSize)
+            .background(background, CircleShape)
+            .wrapContentSize(Alignment.Center),
+    )
+}
+
+/**
+ * Renders "Author • timestamp" as a single annotated-string line, plus an optional channel line
+ * beneath it.
+ *
+ * Using [buildAnnotatedString] keeps the two color/size styles on one baseline so the text wraps
+ * naturally at narrow widths without being split into two adjacent `Text` composables.
+ */
+@Composable
+private fun AuthorLine(comment: ThreadComment, style: ThreadStyle) {
+    val text = buildAnnotatedString {
+        withStyle(
+            SpanStyle(
+                color = style.primaryTextColor,
+                fontSize = style.authorStyle.fontSize,
+                fontWeight = style.authorStyle.fontWeight ?: FontWeight.W600,
+                letterSpacing = style.authorStyle.letterSpacing,
+            )
+        ) { append(comment.author) }
+        append("  ")
+        withStyle(
+            SpanStyle(
+                color = style.secondaryTextColor,
+                fontSize = style.timestampStyle.fontSize,
+                fontWeight = style.timestampStyle.fontWeight ?: FontWeight.W500,
+                letterSpacing = style.timestampStyle.letterSpacing,
+            )
+        ) { append("• ${comment.timestamp}") }
+    }
+    Text(text = text, style = style.authorStyle)
+
+    if (!comment.channel.isNullOrEmpty()) {
+        Spacer(Modifier.height(style.contentVerticalGap / 2))
+        Text(
+            text = comment.channel,
+            style = style.channelStyle.copy(color = style.secondaryTextColor),
+        )
+    }
+}
+
+/**
+ * Horizontal row of colored pill badges (`ThreadTag`s).
+ *
+ * Inter-tag spacing reuses [ThreadStyle.contentVerticalGap] so a single style property controls
+ * all of the row's micro-spacing.
+ */
+@Composable
+private fun TagRow(tags: List<ThreadTag>, style: ThreadStyle) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        tags.forEachIndexed { index, tag ->
+            if (index > 0) Spacer(Modifier.width(style.contentVerticalGap))
+            Text(
+                text = tag.text,
+                style = style.tagStyle.copy(color = tag.contentColor),
+                modifier = Modifier
+                    .background(tag.background, RoundedCornerShape(style.contentVerticalGap / 2))
+                    .padding(
+                        horizontal = style.contentVerticalGap,
+                        vertical = style.contentVerticalGap / 3,
+                    ),
+            )
+        }
+    }
+}
+
+/**
+ * Bottom-of-row action cluster: [ToggleChip] (only when the row has replies) followed by
+ * [ReplyChip].
+ */
+@Composable
+private fun ActionRow(
+    row: VisibleRow,
+    style: ThreadStyle,
+    onToggle: () -> Unit,
+    onReplyClick: () -> Unit,
+) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        if (row.hasReplies) {
+            ToggleChip(row = row, style = style, onClick = onToggle)
+            Spacer(Modifier.width(style.avatarToContentSpacing))
+        }
+        ReplyChip(style = style, onClick = onReplyClick)
+    }
+}
+
+/**
+ * Expand/collapse control. Label and icon both flip based on [VisibleRow.isExpanded]; icon is
+ * omitted entirely if the caller didn't supply a painter (returns null).
+ */
+@Composable
+private fun ToggleChip(row: VisibleRow, style: ThreadStyle, onClick: () -> Unit) {
+    val label = if (row.isExpanded) {
+        "Hide replies"
+    } else {
+        val count = row.comment.replies.size
+        if (count == 1) "Show 1 reply" else "Show $count replies"
+    }
+    val icon = if (row.isExpanded) style.collapseIcon() else style.expandIcon()
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.clickable(onClick = onClick),
+    ) {
+        if (icon != null) {
+            Image(
+                painter = icon,
+                contentDescription = null,
+                modifier = Modifier.size(style.avatarSize * 0.7f),
+            )
+            Spacer(Modifier.width(style.contentVerticalGap))
+        }
+        Text(
+            text = label,
+            style = style.actionStyle.copy(color = style.primaryTextColor),
+        )
+    }
+}
+
+/**
+ * Reply action. Label comes from [ThreadStyle.replyText] (for localization); icon is optional.
+ */
+@Composable
+private fun ReplyChip(style: ThreadStyle, onClick: () -> Unit) {
+    val icon = style.replyIcon()
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.clickable(onClick = onClick),
+    ) {
+        if (icon != null) {
+            Image(
+                painter = icon,
+                contentDescription = null,
+                modifier = Modifier.size(style.avatarSize * 0.7f),
+            )
+            Spacer(Modifier.width(style.contentVerticalGap))
+        }
+        Text(
+            text = style.replyText,
+            style = style.actionStyle.copy(color = style.primaryTextColor),
+        )
+    }
+}

--- a/core/chat-thread/src/commonMain/kotlin/com/example/chatthread/internal/RowConnectors.kt
+++ b/core/chat-thread/src/commonMain/kotlin/com/example/chatthread/internal/RowConnectors.kt
@@ -1,0 +1,130 @@
+package com.example.chatthread.internal
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.unit.Dp
+
+/**
+ * Draws the tree connector lines (ancestor guides, parent→avatar branch, own trunk) behind a row.
+ *
+ * All geometry is derived from [avatarSize], [indentPerLevel] and the depth metadata carried on
+ * each [VisibleRow], so no magic numbers live in this file — tweak [avatarSize] or [indentPerLevel]
+ * in [com.example.chatthread.ThreadStyle] and the lines stay aligned.
+ *
+ * Column math:
+ * - A row at depth `d` places its avatar at x = `d * indentPerLevel`.
+ * - An ancestor at depth `i` has its own "trunk column" (the vertical through the middle of its
+ *   avatar) at x = `(i) * indent + radius`. For drawing *pass-through* guides on descendants we
+ *   shift to `(i-1) * indent + radius` because on a descendant row the ancestor's avatar column
+ *   corresponds to i-1 indents from the left.
+ * - `connectorY` (the horizontal branch height) sits at `radius`, i.e. the vertical centre of the
+ *   avatar, so every horizontal line meets the avatar's left edge cleanly.
+ *
+ * The draw happens in three phases:
+ *   1. Ancestor pass-through guides.
+ *   2. A parent-to-avatar branch — rounded L if this is the last sibling, tee (continuous trunk +
+ *      short horizontal) otherwise.
+ *   3. This row's own downward trunk, drawn only when expanded so the line reaches the first child
+ *      with no gap.
+ *
+ * @param depth 0-based tree depth of this row.
+ * @param ancestorHasMoreSiblings Per-depth "ancestor has later siblings" flags; see [VisibleRow].
+ * @param isLastSiblingAtDepth Whether this row is the last among its siblings.
+ * @param isExpanded Whether this row is currently expanded (drives phase 3).
+ * @param avatarSize Avatar diameter; half of this is the radius used for geometry.
+ * @param indentPerLevel Horizontal indent added per depth level.
+ * @param cornerRadius Corner rounding for the last-sibling L connector; clamped to avatar radius.
+ * @param strokeWidth Stroke thickness for every line.
+ * @param color Line color.
+ */
+internal fun Modifier.threadConnectors(
+    depth: Int,
+    ancestorHasMoreSiblings: BooleanArray,
+    isLastSiblingAtDepth: Boolean,
+    isExpanded: Boolean,
+    avatarSize: Dp,
+    indentPerLevel: Dp,
+    cornerRadius: Dp,
+    strokeWidth: Dp,
+    color: Color,
+): Modifier = this.drawBehind {
+    val indentPx = indentPerLevel.toPx()
+    val radiusPx = avatarSize.toPx() / 2f
+    val cornerPx = cornerRadius.toPx().coerceAtMost(radiusPx)
+    val strokePx = strokeWidth.toPx()
+    val stroke = Stroke(width = strokePx, cap = StrokeCap.Round, join = StrokeJoin.Round)
+
+    val connectorY = radiusPx
+
+    // 1. Ancestor guide lines — for each ancestor at depth i (1 <= i < depth) whose subtree has
+    //    more siblings below, draw a vertical guide at that ancestor's trunk column (i-1)*indent+radius.
+    //    Skip i=0 (roots have no shared parent trunk) and skip the direct parent (i=depth-1 is
+    //    still included here only if i >= 1; the direct parent's own trunk column sits one level
+    //    out from the L-connector column handled below, so no overlap).
+    for (i in 1 until ancestorHasMoreSiblings.size) {
+        if (!ancestorHasMoreSiblings[i]) continue
+        val x = (i - 1) * indentPx + radiusPx
+        drawLine(
+            color = color,
+            start = Offset(x, 0f),
+            end = Offset(x, size.height),
+            strokeWidth = strokePx,
+            cap = StrokeCap.Butt,
+        )
+    }
+
+    // 2. Line from parent's trunk into this avatar (skipped for depth 0 roots).
+    if (depth > 0) {
+        val parentTrunkX = (depth - 1) * indentPx + radiusPx
+        val avatarLeftX = depth * indentPx
+
+        if (isLastSiblingAtDepth) {
+            // Rounded L: trunk down to just before the turn, then bezier, then horizontal.
+            val path = Path().apply {
+                moveTo(parentTrunkX, 0f)
+                lineTo(parentTrunkX, connectorY - cornerPx)
+                quadraticTo(
+                    parentTrunkX, connectorY,
+                    parentTrunkX + cornerPx, connectorY,
+                )
+                lineTo(avatarLeftX, connectorY)
+            }
+            drawPath(path = path, color = color, style = stroke)
+        } else {
+            // Tee: continuous vertical trunk through the row, plus a horizontal branch.
+            drawLine(
+                color = color,
+                start = Offset(parentTrunkX, 0f),
+                end = Offset(parentTrunkX, size.height),
+                strokeWidth = strokePx,
+                cap = StrokeCap.Butt,
+            )
+            drawLine(
+                color = color,
+                start = Offset(parentTrunkX, connectorY),
+                end = Offset(avatarLeftX, connectorY),
+                strokeWidth = strokePx,
+                cap = StrokeCap.Round,
+            )
+        }
+    }
+
+    // 3. If this row is expanded and has children, its own trunk extends down from the avatar
+    //    to the next row. Draw it here so there's no gap between the avatar and the first child.
+    if (isExpanded) {
+        val ownTrunkX = depth * indentPx + radiusPx
+        drawLine(
+            color = color,
+            start = Offset(ownTrunkX, connectorY + radiusPx),
+            end = Offset(ownTrunkX, size.height),
+            strokeWidth = strokePx,
+            cap = StrokeCap.Butt,
+        )
+    }
+}

--- a/core/chat-thread/src/commonMain/kotlin/com/example/chatthread/internal/ThreadFlattener.kt
+++ b/core/chat-thread/src/commonMain/kotlin/com/example/chatthread/internal/ThreadFlattener.kt
@@ -1,0 +1,113 @@
+package com.example.chatthread.internal
+
+import androidx.compose.runtime.Immutable
+import com.example.chatthread.ThreadComment
+
+/**
+ * One row produced by [flattenThread]. Carries everything a row needs to render itself without
+ * looking at its neighbours.
+ *
+ * @property comment The underlying comment being shown on this row.
+ * @property depth 0 for root comments, 1 for their replies, and so on.
+ * @property ancestorHasMoreSiblings For each ancestor at depth i, `true` iff that ancestor has
+ *   later siblings. Consumed by the connector renderer to decide where to draw vertical
+ *   "pass-through" guide lines so the tree reads correctly at arbitrary depth.
+ * @property isLastSiblingAtDepth True when this row has no later siblings at its own depth.
+ *   Controls rounded-L (last) vs tee (not last) connector shape.
+ * @property hasReplies Whether this comment has any replies (regardless of expansion state). Drives
+ *   whether the "Show N replies" chip is shown.
+ * @property isExpanded Whether this comment is currently expanded. Drives the own-trunk line
+ *   segment that descends from this row's avatar to the first child.
+ */
+@Immutable
+internal data class VisibleRow(
+    val comment: ThreadComment,
+    val depth: Int,
+    val ancestorHasMoreSiblings: BooleanArray,
+    val isLastSiblingAtDepth: Boolean,
+    val hasReplies: Boolean,
+    val isExpanded: Boolean,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is VisibleRow) return false
+        return comment.id == other.comment.id &&
+            depth == other.depth &&
+            isLastSiblingAtDepth == other.isLastSiblingAtDepth &&
+            hasReplies == other.hasReplies &&
+            isExpanded == other.isExpanded &&
+            ancestorHasMoreSiblings.contentEquals(other.ancestorHasMoreSiblings)
+    }
+
+    override fun hashCode(): Int {
+        var result = comment.id.hashCode()
+        result = 31 * result + depth
+        result = 31 * result + ancestorHasMoreSiblings.contentHashCode()
+        result = 31 * result + isLastSiblingAtDepth.hashCode()
+        result = 31 * result + hasReplies.hashCode()
+        result = 31 * result + isExpanded.hashCode()
+        return result
+    }
+}
+
+/**
+ * Walks the comment tree in depth-first order and returns the rows that should currently be
+ * visible, each annotated with the metadata needed to draw connectors in isolation.
+ *
+ * Collapsing happens implicitly: children are only appended when their parent is in [expandedIds],
+ * so collapsing an ancestor automatically hides every descendant in one step, even if descendants
+ * remain in the expanded set.
+ *
+ * @param roots Top-level comments.
+ * @param expandedIds Ids whose replies should be visible.
+ * @return Flat list of rows in rendering order.
+ */
+internal fun flattenThread(
+    roots: List<ThreadComment>,
+    expandedIds: Set<String>,
+): List<VisibleRow> {
+    val out = ArrayList<VisibleRow>(roots.size)
+    val ancestorStack = ArrayList<Boolean>()
+    flattenInto(roots, expandedIds, out, ancestorStack)
+    return out
+}
+
+/**
+ * Recursive worker for [flattenThread].
+ *
+ * Uses an explicit [ancestorStack] so each row records a snapshot of "does each of my ancestors
+ * have more siblings below?" — that snapshot is precisely what the connector renderer needs to
+ * know to draw pass-through guide lines without cross-row measurement.
+ *
+ * The `!isLast` push before descending is the key: when we walk into a child, the parent's
+ * remaining-siblings flag becomes the child's ancestor flag. Popping after descent preserves the
+ * invariant that `ancestorStack.size == current depth`.
+ */
+private fun flattenInto(
+    siblings: List<ThreadComment>,
+    expandedIds: Set<String>,
+    out: MutableList<VisibleRow>,
+    ancestorStack: MutableList<Boolean>,
+) {
+    val lastIndex = siblings.lastIndex
+    siblings.forEachIndexed { index, comment ->
+        val isLast = index == lastIndex
+        val hasReplies = comment.replies.isNotEmpty()
+        val isExpanded = hasReplies && comment.id in expandedIds
+        out.add(
+            VisibleRow(
+                comment = comment,
+                depth = ancestorStack.size,
+                ancestorHasMoreSiblings = ancestorStack.toBooleanArray(),
+                isLastSiblingAtDepth = isLast,
+                hasReplies = hasReplies,
+                isExpanded = isExpanded,
+            )
+        )
+        if (isExpanded) {
+            ancestorStack.add(!isLast)
+            flattenInto(comment.replies, expandedIds, out, ancestorStack)
+            ancestorStack.removeAt(ancestorStack.lastIndex)
+        }
+    }
+}

--- a/core/chat-thread/src/commonTest/kotlin/com/example/chatthread/internal/ThreadFlattenerTest.kt
+++ b/core/chat-thread/src/commonTest/kotlin/com/example/chatthread/internal/ThreadFlattenerTest.kt
@@ -1,0 +1,123 @@
+package com.example.chatthread.internal
+
+import androidx.compose.ui.graphics.Color
+import com.example.chatthread.ThreadComment
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [flattenThread].
+ *
+ * Ported from the upstream library's JUnit4 test to `kotlin.test` so it runs on every KMP target
+ * (same cases, same assertions). The flattener is the one piece of pure logic in the library —
+ * every row's rendering decision flows from the [VisibleRow] metadata it produces.
+ */
+class ThreadFlattenerTest {
+
+    /** Short-hand builder for a comment with only an id and children — cuts noise in test cases. */
+    private fun c(id: String, vararg replies: ThreadComment) = ThreadComment(
+        id = id,
+        author = id,
+        avatarBackground = Color.Red,
+        timestamp = "",
+        body = "",
+        replies = replies.toList(),
+    )
+
+    /**
+     * With no ids in `expandedIds`, only the root comments are visible, depth is 0, and the
+     * last-sibling flag correctly differentiates the two roots.
+     */
+    @Test
+    fun fullyCollapsed_onlyRootsVisible() {
+        val roots = listOf(
+            c("a", c("a1"), c("a2")),
+            c("b", c("b1")),
+        )
+        val rows = flattenThread(roots, expandedIds = emptySet())
+
+        assertEquals(listOf("a", "b"), rows.map { it.comment.id })
+        assertEquals(0, rows[0].depth)
+        assertContentEquals(booleanArrayOf(), rows[0].ancestorHasMoreSiblings)
+        assertFalse(rows[0].isLastSiblingAtDepth)
+        assertTrue(rows[1].isLastSiblingAtDepth)
+        assertTrue(rows[0].hasReplies)
+        assertFalse(rows[0].isExpanded)
+    }
+
+    /**
+     * Expanding a single root exposes its children with depth 1. Each child's
+     * `ancestorHasMoreSiblings[0]` is `false` because the root has no later siblings, and the
+     * last-sibling flag only fires on the final child.
+     */
+    @Test
+    fun singleRootExpanded_revealsChildrenWithCorrectDepthMetadata() {
+        val roots = listOf(
+            c("root", c("a"), c("b"), c("c"))
+        )
+        val rows = flattenThread(roots, expandedIds = setOf("root"))
+
+        assertEquals(listOf("root", "a", "b", "c"), rows.map { it.comment.id })
+        assertEquals(1, rows[1].depth)
+        assertEquals(1, rows[2].depth)
+        assertEquals(1, rows[3].depth)
+        // Children see root's !isLast=false (root is solo).
+        assertContentEquals(booleanArrayOf(false), rows[1].ancestorHasMoreSiblings)
+        assertFalse(rows[1].isLastSiblingAtDepth)
+        assertFalse(rows[2].isLastSiblingAtDepth)
+        assertTrue(rows[3].isLastSiblingAtDepth)
+    }
+
+    /**
+     * Verifies the ancestor-stack snapshot at arbitrary depth. For a three-level expansion, the
+     * `ancestorHasMoreSiblings` vector must reflect the "does this ancestor have later siblings?"
+     * answer for every enclosing level — this is what drives correct pass-through guide lines.
+     */
+    @Test
+    fun nestedExpansion_ancestorFlagsReflectSiblingPresence() {
+        // root -> [A, B]; A -> [A1, A2]; A2 -> [A2a]
+        val roots = listOf(
+            c(
+                "root",
+                c("A", c("A1"), c("A2", c("A2a"))),
+                c("B"),
+            ),
+        )
+        val rows = flattenThread(roots, expandedIds = setOf("root", "A", "A2"))
+
+        assertEquals(
+            listOf("root", "A", "A1", "A2", "A2a", "B"),
+            rows.map { it.comment.id },
+        )
+
+        val a1 = rows.first { it.comment.id == "A1" }
+        // A1 is at depth 2: anc[0]=root's !isLast=false; anc[1]=A's !isLast=true (B follows A).
+        assertContentEquals(booleanArrayOf(false, true), a1.ancestorHasMoreSiblings)
+        assertFalse(a1.isLastSiblingAtDepth)
+
+        val a2a = rows.first { it.comment.id == "A2a" }
+        // A2a depth 3: anc = [false (root solo), true (A has B), false (A2 is last of A's children)].
+        assertContentEquals(booleanArrayOf(false, true, false), a2a.ancestorHasMoreSiblings)
+        assertTrue(a2a.isLastSiblingAtDepth)
+
+        val b = rows.first { it.comment.id == "B" }
+        assertEquals(1, b.depth)
+        assertTrue(b.isLastSiblingAtDepth)
+    }
+
+    /**
+     * Collapsing is implicit: if the parent is not in `expandedIds`, its children never appear
+     * even when the children's own ids remain in the set. That means UI code never has to walk
+     * the tree to "clean up" expanded descendants when a parent collapses.
+     */
+    @Test
+    fun collapsingDoesNotRemoveExpandedStateOfDescendants() {
+        // Collapsing A should hide A's children even if A is still in expandedIds.
+        val roots = listOf(c("root", c("A", c("A1"))))
+        val rows = flattenThread(roots, expandedIds = setOf("A")) // root NOT expanded
+        assertEquals(listOf("root"), rows.map { it.comment.id })
+    }
+}

--- a/feature/tweet/data/src/commonMain/kotlin/com/example/twitturin/feature/tweet/data/TweetDtos.kt
+++ b/feature/tweet/data/src/commonMain/kotlin/com/example/twitturin/feature/tweet/data/TweetDtos.kt
@@ -39,6 +39,26 @@ data class LikeRequestDto(
     @SerialName("count") val count: String,
 )
 
+/**
+ * One node of the reply tree returned by `GET tweets/{id}/replies`. Unlike tweets, replies nest:
+ * each carries its own `replies` array to arbitrary depth (the backend's Reply mongoose model).
+ * The `tweet`/`parentTweet`/`parentReply` pointer fields are ignored — nesting is already
+ * expressed by the tree shape.
+ */
+@OptIn(ExperimentalSerializationApi::class)
+@Serializable
+data class ReplyDto(
+    @SerialName("id") val id: String? = null,
+    @SerialName("content") val content: String? = null,
+    @SerialName("author") val author: TweetAuthorDto? = null,
+    @SerialName("createdAt") val createdAt: String? = null,
+    @SerialName("updatedAt") val updatedAt: String? = null,
+    @SerialName("likes") val likes: Int? = null,
+    @SerialName("likedBy") @JsonNames("likesBy") val likedBy: List<String>? = null,
+    @SerialName("isEdited") val isEdited: Boolean? = null,
+    @SerialName("replies") val replies: List<ReplyDto>? = null,
+)
+
 @Serializable
 data class TweetLikerDto(
     @SerialName("id") val id: String? = null,

--- a/feature/tweet/data/src/commonMain/kotlin/com/example/twitturin/feature/tweet/data/TweetMapper.kt
+++ b/feature/tweet/data/src/commonMain/kotlin/com/example/twitturin/feature/tweet/data/TweetMapper.kt
@@ -1,5 +1,6 @@
 package com.example.twitturin.feature.tweet.data
 
+import com.example.twitturin.feature.tweet.domain.Reply
 import com.example.twitturin.feature.tweet.domain.Tweet
 import com.example.twitturin.feature.tweet.domain.TweetAuthor
 import com.example.twitturin.feature.tweet.domain.TweetLiker
@@ -20,6 +21,17 @@ fun TweetAuthorDto.toTweetAuthor(): TweetAuthor = TweetAuthor(
     username = username,
     fullName = fullName,
     profilePicture = profilePicture,
+)
+
+fun ReplyDto.toReply(): Reply = Reply(
+    id = id.orEmpty(),
+    content = content.orEmpty(),
+    author = author?.toTweetAuthor(),
+    createdAt = createdAt,
+    likes = likes ?: 0,
+    likedBy = likedBy ?: emptyList(),
+    isEdited = isEdited ?: false,
+    replies = replies?.map { it.toReply() } ?: emptyList(),
 )
 
 fun TweetLikerDto.toTweetLiker(): TweetLiker = TweetLiker(

--- a/feature/tweet/data/src/commonMain/kotlin/com/example/twitturin/feature/tweet/data/TweetRepositoryImpl.kt
+++ b/feature/tweet/data/src/commonMain/kotlin/com/example/twitturin/feature/tweet/data/TweetRepositoryImpl.kt
@@ -8,6 +8,7 @@ import com.example.twitturin.core.domain.util.DataError
 import com.example.twitturin.core.domain.util.EmptyResult
 import com.example.twitturin.core.domain.util.Result
 import com.example.twitturin.core.domain.util.map
+import com.example.twitturin.feature.tweet.domain.Reply
 import com.example.twitturin.feature.tweet.domain.Tweet
 import com.example.twitturin.feature.tweet.domain.TweetLiker
 import com.example.twitturin.feature.tweet.domain.TweetRepository
@@ -53,14 +54,21 @@ class TweetRepositoryImpl(
         return httpClient.get<TweetDto>(route = "tweets/$tweetId").map { it.toTweet() }
     }
 
-    override suspend fun getReplies(tweetId: String): Result<List<Tweet>, DataError.Network> {
-        return httpClient.get<List<TweetDto>>(route = "tweets/$tweetId/replies")
-            .map { list -> list.map { it.toTweet() } }
+    override suspend fun getReplies(tweetId: String): Result<List<Reply>, DataError.Network> {
+        return httpClient.get<List<ReplyDto>>(route = "tweets/$tweetId/replies")
+            .map { list -> list.map { it.toReply() } }
     }
 
     override suspend fun postReply(tweetId: String, content: String): EmptyResult<DataError.Network> {
         return httpClient.post<PostTweetRequestDto, Unit>(
             route = "tweets/$tweetId/replies",
+            body = PostTweetRequestDto(content = content),
+        )
+    }
+
+    override suspend fun postReplyToReply(replyId: String, content: String): EmptyResult<DataError.Network> {
+        return httpClient.post<PostTweetRequestDto, Unit>(
+            route = "replies/$replyId",
             body = PostTweetRequestDto(content = content),
         )
     }

--- a/feature/tweet/data/src/commonTest/kotlin/com/example/twitturin/feature/tweet/data/ReplyDtoTest.kt
+++ b/feature/tweet/data/src/commonTest/kotlin/com/example/twitturin/feature/tweet/data/ReplyDtoTest.kt
@@ -1,0 +1,106 @@
+package com.example.twitturin.feature.tweet.data
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Parses a trimmed copy of a real `GET tweets/{id}/replies` payload (captured from the live
+ * backend) and checks that the recursive [ReplyDto] tree round-trips into [Reply] with nesting
+ * intact and the pointer fields (`tweet`/`parentTweet`/`parentReply`) ignored.
+ */
+class ReplyDtoTest {
+
+    // Same settings as core:data HttpClientFactory's ContentNegotiation Json.
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+    }
+
+    private val payload = """
+        [
+          {
+            "content": "Answer",
+            "likedBy": ["657f41612107c8081af6c9f2"],
+            "tweet": "694d185f6d2f09b3f7177eaf",
+            "parentTweet": "694d185f6d2f09b3f7177eaf",
+            "author": {
+              "major": "SE",
+              "username": "junkidesu",
+              "fullName": "Anwar Sh.",
+              "kind": "student",
+              "followingCount": 12,
+              "id": "657f41612107c8081af6c9f2"
+            },
+            "createdAt": "2025-12-25T10:56:46.214Z",
+            "updatedAt": "2025-12-25T10:56:46.214Z",
+            "likes": 1,
+            "isEdited": false,
+            "replies": [
+              {
+                "content": "Second",
+                "likedBy": [],
+                "tweet": "694d185f6d2f09b3f7177eaf",
+                "parentReply": "694d186e6d2f09b3f7177ec8",
+                "author": {
+                  "username": "invoker",
+                  "fullName": "Salokhiddinov Mukhammadamin",
+                  "id": "6581b2da3a45193233759a26"
+                },
+                "createdAt": "2025-12-25T10:56:57.532Z",
+                "updatedAt": "2025-12-25T10:56:57.532Z",
+                "likes": 0,
+                "isEdited": false,
+                "replies": [],
+                "id": "694d18796d2f09b3f7177ede"
+              }
+            ],
+            "id": "694d186e6d2f09b3f7177ec8"
+          },
+          {
+            "content": "how you been ?",
+            "likedBy": [],
+            "tweet": "694d185f6d2f09b3f7177eaf",
+            "parentTweet": "694d185f6d2f09b3f7177eaf",
+            "author": null,
+            "createdAt": "2026-01-21T15:42:32.715Z",
+            "updatedAt": "2026-01-21T15:42:32.715Z",
+            "likes": 0,
+            "isEdited": false,
+            "replies": [],
+            "id": "6970f3e86d2f09b3f71782d1"
+          }
+        ]
+    """.trimIndent()
+
+    @Test
+    fun repliesPayload_parsesAsRecursiveTree() {
+        val dtos = json.decodeFromString<List<ReplyDto>>(payload)
+
+        assertEquals(2, dtos.size)
+        assertEquals("Answer", dtos[0].content)
+        assertEquals(1, dtos[0].replies?.size)
+        assertEquals("Second", dtos[0].replies?.first()?.content)
+        assertTrue(dtos[1].replies.isNullOrEmpty())
+    }
+
+    @Test
+    fun toReply_keepsNestingAndDefaultsMissingFields() {
+        val replies = json.decodeFromString<List<ReplyDto>>(payload).map { it.toReply() }
+
+        val root = replies[0]
+        assertEquals("694d186e6d2f09b3f7177ec8", root.id)
+        assertEquals("Anwar Sh.", root.author?.fullName)
+        assertEquals(1, root.replies.size)
+        assertEquals("694d18796d2f09b3f7177ede", root.replies[0].id)
+        assertEquals("invoker", root.replies[0].author?.username)
+        assertTrue(root.replies[0].replies.isEmpty())
+
+        // Null author + empty lists fall back to safe defaults.
+        val second = replies[1]
+        assertEquals(null, second.author)
+        assertTrue(second.likedBy.isEmpty())
+        assertTrue(second.replies.isEmpty())
+    }
+}

--- a/feature/tweet/domain/src/commonMain/kotlin/com/example/twitturin/feature/tweet/domain/Reply.kt
+++ b/feature/tweet/domain/src/commonMain/kotlin/com/example/twitturin/feature/tweet/domain/Reply.kt
@@ -1,0 +1,19 @@
+package com.example.twitturin.feature.tweet.domain
+
+/**
+ * One node of a tweet's reply tree (`GET tweets/{id}/replies`).
+ *
+ * Replies are a separate backend resource from tweets (a reply id 404s on `tweets/{id}`), and
+ * they nest: [replies] holds the children to arbitrary depth. Reply-to-reply writes go through
+ * `POST replies/{id}`, not the tweets routes.
+ */
+data class Reply(
+    val id: String,
+    val content: String,
+    val author: TweetAuthor?,
+    val createdAt: String?,
+    val likes: Int,
+    val likedBy: List<String>,
+    val isEdited: Boolean,
+    val replies: List<Reply>,
+)

--- a/feature/tweet/domain/src/commonMain/kotlin/com/example/twitturin/feature/tweet/domain/TweetRepository.kt
+++ b/feature/tweet/domain/src/commonMain/kotlin/com/example/twitturin/feature/tweet/domain/TweetRepository.kt
@@ -33,11 +33,14 @@ interface TweetRepository {
     /** A single tweet by id (`GET tweets/{id}`). */
     suspend fun getTweet(tweetId: String): Result<Tweet, DataError.Network>
 
-    /** Replies to a tweet (`GET tweets/{id}/replies`); replies are themselves tweet-shaped. */
-    suspend fun getReplies(tweetId: String): Result<List<Tweet>, DataError.Network>
+    /** The reply tree of a tweet (`GET tweets/{id}/replies`); each [Reply] nests its children. */
+    suspend fun getReplies(tweetId: String): Result<List<Reply>, DataError.Network>
 
     /** Reply to a tweet (`POST tweets/{id}/replies`, auth). */
     suspend fun postReply(tweetId: String, content: String): EmptyResult<DataError.Network>
+
+    /** Reply to another reply (`POST replies/{id}`, auth) — nests under it in the reply tree. */
+    suspend fun postReplyToReply(replyId: String, content: String): EmptyResult<DataError.Network>
 
     /** Users who liked a tweet (`GET tweets/{id}/likes`). */
     suspend fun getLikers(tweetId: String): Result<List<TweetLiker>, DataError.Network>

--- a/feature/tweet/presentation/src/commonMain/kotlin/com/example/twitturin/feature/tweet/presentation/ReplyUi.kt
+++ b/feature/tweet/presentation/src/commonMain/kotlin/com/example/twitturin/feature/tweet/presentation/ReplyUi.kt
@@ -1,0 +1,23 @@
+package com.example.twitturin.feature.tweet.presentation
+
+import com.example.twitturin.feature.tweet.domain.Reply
+
+/** Display-ready node of a tweet's reply tree. No nullable display fields. */
+data class ReplyUi(
+    val id: String,
+    val authorName: String,
+    val authorUsername: String,
+    val content: String,
+    val date: String,
+    val replies: List<ReplyUi>,
+)
+
+fun Reply.toReplyUi(): ReplyUi = ReplyUi(
+    id = id,
+    authorName = author?.fullName ?: "Twittur User",
+    authorUsername = author?.username.orEmpty(),
+    content = content,
+    // The API returns ISO-8601; show just the date part to avoid a date-format dependency.
+    date = createdAt?.substringBefore("T").orEmpty(),
+    replies = replies.map { it.toReplyUi() },
+)

--- a/feature/tweet/presentation/src/commonMain/kotlin/com/example/twitturin/feature/tweet/presentation/detail/DetailAction.kt
+++ b/feature/tweet/presentation/src/commonMain/kotlin/com/example/twitturin/feature/tweet/presentation/detail/DetailAction.kt
@@ -1,10 +1,18 @@
 package com.example.twitturin.feature.tweet.presentation.detail
 
+import com.example.twitturin.feature.tweet.presentation.ReplyUi
+
 sealed interface DetailAction {
     data object OnRefresh : DetailAction
     data class OnReplyChange(val text: String) : DetailAction
     data class OnSendReply(val content: String) : DetailAction
-    data class OnReplyClick(val tweetId: String) : DetailAction
+
+    /** "Reply" tapped on a thread row — aim the composer at that reply. */
+    data class OnReplyToReply(val reply: ReplyUi) : DetailAction
+
+    /** Dismiss the "Replying to @user" target and go back to replying to the tweet itself. */
+    data object OnCancelReplyTarget : DetailAction
+
     data object OnOpenLikes : DetailAction
     data object OnLike : DetailAction
     data object OnDelete : DetailAction

--- a/feature/tweet/presentation/src/commonMain/kotlin/com/example/twitturin/feature/tweet/presentation/detail/DetailEvent.kt
+++ b/feature/tweet/presentation/src/commonMain/kotlin/com/example/twitturin/feature/tweet/presentation/detail/DetailEvent.kt
@@ -3,7 +3,6 @@ package com.example.twitturin.feature.tweet.presentation.detail
 import com.example.twitturin.core.presentation.UiText
 
 sealed interface DetailEvent {
-    data class NavigateToTweet(val tweetId: String) : DetailEvent
     data class NavigateToLikes(val tweetId: String) : DetailEvent
     data object Deleted : DetailEvent
     data class ShowError(val message: UiText) : DetailEvent

--- a/feature/tweet/presentation/src/commonMain/kotlin/com/example/twitturin/feature/tweet/presentation/detail/DetailScreen.kt
+++ b/feature/tweet/presentation/src/commonMain/kotlin/com/example/twitturin/feature/tweet/presentation/detail/DetailScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -12,8 +13,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -42,8 +41,11 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.example.chatthread.CollapsibleChatThread
+import com.example.chatthread.rememberThreadState
 import com.example.twitturin.core.designsystem.component.LoadingBox
 import com.example.twitturin.core.designsystem.component.TwitturTopBarMore
 import com.example.twitturin.core.designsystem.icon.TwitturIcons
@@ -58,7 +60,6 @@ import com.example.twitturin.core.presentation.ObserveAsEvents
 import com.example.twitturin.core.presentation.UiText
 import com.example.twitturin.feature.tweet.presentation.TweetUi
 import com.example.twitturin.feature.tweet.presentation.components.TweetAvatar
-import com.example.twitturin.feature.tweet.presentation.components.TweetItem
 import kotlinx.coroutines.launch
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -81,7 +82,6 @@ fun DetailRoot(
 
     ObserveAsEvents(viewModel.events) { event ->
         when (event) {
-            is DetailEvent.NavigateToTweet -> onOpenTweet(event.tweetId)
             is DetailEvent.NavigateToLikes -> onOpenLikes(event.tweetId)
             DetailEvent.Deleted -> onBack()
             is DetailEvent.ShowError -> pendingError = event.message
@@ -136,6 +136,11 @@ fun DetailScreen(
         }
     }
 
+    // Aiming at a thread reply (its "Reply" chip) also raises the composer.
+    LaunchedEffect(state.replyTarget) {
+        if (state.replyTarget != null) focusTick++
+    }
+
     fun report() {
         scope.launch { snackbarHostState.showSnackbar("Thanks — we'll take a look.") }
     }
@@ -163,33 +168,63 @@ fun DetailScreen(
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },
         bottomBar = {
-            Row(
+            Column(
                 modifier = Modifier
                     .background(MaterialTheme.colorScheme.background)
-                    .fillMaxWidth()
-                    .padding(horizontal = 12.dp, vertical = 8.dp),
-                verticalAlignment = Alignment.CenterVertically,
+                    .fillMaxWidth(),
             ) {
-                OutlinedTextField(
-                    modifier = Modifier.weight(1f).focusRequester(focusRequester),
-                    value = state.replyDraft,
-                    onValueChange = { onAction(DetailAction.OnReplyChange(it)) },
-                    placeholder = { Text(text = "Reply", color = Hint) },
-                    shape = RoundedCornerShape(24.dp),
-                    maxLines = 3,
-                    colors = OutlinedTextFieldDefaults.colors(
-                        focusedBorderColor = Brand,
-                        unfocusedBorderColor = DividerLine,
-                        cursorColor = Brand,
-                    ),
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                Button(
-                    onClick = { onAction(DetailAction.OnSendReply(state.replyDraft)) },
-                    enabled = state.replyDraft.isNotBlank() && !state.isSendingReply,
-                    shape = RoundedCornerShape(22.dp),
-                    colors = ButtonDefaults.buttonColors(containerColor = Brand, contentColor = OnBrand),
-                ) { Text("Send", fontWeight = FontWeight.Bold) }
+                // Nested-reply target chip: Send goes under this reply until dismissed.
+                state.replyTarget?.let { target ->
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(start = 16.dp, end = 12.dp, top = 6.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = "Replying to " +
+                                if (target.authorUsername.isNotBlank()) "@${target.authorUsername}" else target.authorName,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = Brand,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.weight(1f),
+                        )
+                        Icon(
+                            imageVector = TwitturIcons.Close,
+                            contentDescription = "Cancel reply",
+                            tint = SecondaryText,
+                            modifier = Modifier
+                                .height(16.dp)
+                                .clickable { onAction(DetailAction.OnCancelReplyTarget) },
+                        )
+                    }
+                }
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 12.dp, vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    OutlinedTextField(
+                        modifier = Modifier.weight(1f).focusRequester(focusRequester),
+                        value = state.replyDraft,
+                        onValueChange = { onAction(DetailAction.OnReplyChange(it)) },
+                        placeholder = { Text(text = "Reply", color = Hint) },
+                        shape = RoundedCornerShape(24.dp),
+                        maxLines = 3,
+                        colors = OutlinedTextFieldDefaults.colors(
+                            focusedBorderColor = Brand,
+                            unfocusedBorderColor = DividerLine,
+                            cursorColor = Brand,
+                        ),
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Button(
+                        onClick = { onAction(DetailAction.OnSendReply(state.replyDraft)) },
+                        enabled = state.replyDraft.isNotBlank() && !state.isSendingReply,
+                        shape = RoundedCornerShape(22.dp),
+                        colors = ButtonDefaults.buttonColors(containerColor = Brand, contentColor = OnBrand),
+                    ) { Text("Send", fontWeight = FontWeight.Bold) }
+                }
             }
         },
     ) { innerPadding ->
@@ -199,25 +234,53 @@ fun DetailScreen(
             }
 
             else -> {
-                LazyColumn(modifier = Modifier.fillMaxSize().padding(innerPadding)) {
+                val threadComments = remember(state.replies) { state.replies.map { it.toThreadComment() } }
+                val repliesById = remember(state.replies) { indexRepliesById(state.replies) }
+                val threadState = rememberThreadState()
+
+                // Open the whole tree whenever a fresh reply tree lands (first load + after posting).
+                LaunchedEffect(state.replies) {
+                    collectExpandableIds(state.replies).forEach(threadState::expand)
+                }
+
+                Column(modifier = Modifier.fillMaxSize().padding(innerPadding)) {
                     state.tweet?.let { tweet ->
-                        item {
-                            DetailHeader(
-                                tweet = tweet,
-                                onReply = { focusTick++ },
-                                onLike = { onAction(DetailAction.OnLike) },
-                                onShare = onShare,
-                                onOpenLikes = { onAction(DetailAction.OnOpenLikes) },
-                            )
-                            HorizontalDivider()
-                        }
-                    }
-                    items(state.replies, key = { it.id }) { reply ->
-                        TweetItem(
-                            tweet = reply,
-                            onClick = { onAction(DetailAction.OnReplyClick(reply.id)) },
+                        DetailHeader(
+                            tweet = tweet,
+                            // Replying from the header targets the tweet itself, not a thread row.
+                            onReply = {
+                                onAction(DetailAction.OnCancelReplyTarget)
+                                focusTick++
+                            },
+                            onLike = { onAction(DetailAction.OnLike) },
+                            onShare = onShare,
+                            onOpenLikes = { onAction(DetailAction.OnOpenLikes) },
                         )
                         HorizontalDivider()
+                    }
+                    if (threadComments.isEmpty()) {
+                        Box(
+                            modifier = Modifier.weight(1f).fillMaxWidth(),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Text(
+                                text = "No replies yet — be the first.",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = Hint,
+                            )
+                        }
+                    } else {
+                        // The reply thread — rendered by the vendored CollapsibleChatThread lib.
+                        CollapsibleChatThread(
+                            comments = threadComments,
+                            state = threadState,
+                            style = twitturThreadStyle(),
+                            modifier = Modifier.weight(1f).fillMaxWidth(),
+                            contentPadding = PaddingValues(start = 16.dp, top = 16.dp, end = 4.dp, bottom = 8.dp),
+                            onReplyClick = { comment ->
+                                repliesById[comment.id]?.let { onAction(DetailAction.OnReplyToReply(it)) }
+                            },
+                        )
                     }
                 }
             }

--- a/feature/tweet/presentation/src/commonMain/kotlin/com/example/twitturin/feature/tweet/presentation/detail/DetailState.kt
+++ b/feature/tweet/presentation/src/commonMain/kotlin/com/example/twitturin/feature/tweet/presentation/detail/DetailState.kt
@@ -1,11 +1,14 @@
 package com.example.twitturin.feature.tweet.presentation.detail
 
+import com.example.twitturin.feature.tweet.presentation.ReplyUi
 import com.example.twitturin.feature.tweet.presentation.TweetUi
 
 data class DetailState(
     val tweet: TweetUi? = null,
-    val replies: List<TweetUi> = emptyList(),
+    val replies: List<ReplyUi> = emptyList(),
     val replyDraft: String = "",
+    /** When set, Send posts a nested reply under this node instead of a top-level reply. */
+    val replyTarget: ReplyUi? = null,
     val isLoading: Boolean = false,
     val isSendingReply: Boolean = false,
 )

--- a/feature/tweet/presentation/src/commonMain/kotlin/com/example/twitturin/feature/tweet/presentation/detail/DetailViewModel.kt
+++ b/feature/tweet/presentation/src/commonMain/kotlin/com/example/twitturin/feature/tweet/presentation/detail/DetailViewModel.kt
@@ -7,6 +7,7 @@ import com.example.twitturin.core.domain.util.onFailure
 import com.example.twitturin.core.domain.util.onSuccess
 import com.example.twitturin.core.presentation.toUiText
 import com.example.twitturin.feature.tweet.domain.TweetRepository
+import com.example.twitturin.feature.tweet.presentation.toReplyUi
 import com.example.twitturin.feature.tweet.presentation.toTweetUi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -41,9 +42,8 @@ class DetailViewModel(
             DetailAction.OnRefresh -> refresh()
             is DetailAction.OnReplyChange -> _state.update { it.copy(replyDraft = action.text) }
             is DetailAction.OnSendReply -> sendReply(action.content)
-            is DetailAction.OnReplyClick -> viewModelScope.launch {
-                _events.send(DetailEvent.NavigateToTweet(action.tweetId))
-            }
+            is DetailAction.OnReplyToReply -> _state.update { it.copy(replyTarget = action.reply) }
+            DetailAction.OnCancelReplyTarget -> _state.update { it.copy(replyTarget = null) }
             DetailAction.OnOpenLikes -> tweetId?.let { id ->
                 viewModelScope.launch { _events.send(DetailEvent.NavigateToLikes(id)) }
             }
@@ -93,15 +93,22 @@ class DetailViewModel(
         }
     }
 
+    /** Posts to the tweet, or under [DetailState.replyTarget] when one is aimed (`POST replies/{id}`). */
     private fun sendReply(content: String) {
         val id = tweetId ?: return
         val text = content.trim()
         if (text.isBlank() || _state.value.isSendingReply) return
+        val target = _state.value.replyTarget
         viewModelScope.launch {
             _state.update { it.copy(isSendingReply = true) }
-            tweetRepository.postReply(id, text)
+            val result = if (target != null) {
+                tweetRepository.postReplyToReply(target.id, text)
+            } else {
+                tweetRepository.postReply(id, text)
+            }
+            result
                 .onSuccess {
-                    _state.update { it.copy(isSendingReply = false, replyDraft = "") }
+                    _state.update { it.copy(isSendingReply = false, replyDraft = "", replyTarget = null) }
                     loadReplies(id)
                 }
                 .onFailure { error ->
@@ -113,7 +120,7 @@ class DetailViewModel(
 
     private suspend fun loadReplies(id: String) {
         tweetRepository.getReplies(id)
-            .onSuccess { replies -> _state.update { it.copy(replies = replies.map { r -> r.toTweetUi(currentUserId) }) } }
+            .onSuccess { replies -> _state.update { it.copy(replies = replies.map { r -> r.toReplyUi() }) } }
             .onFailure { error -> _events.send(DetailEvent.ShowError(error.toUiText())) }
     }
 }

--- a/feature/tweet/presentation/src/commonMain/kotlin/com/example/twitturin/feature/tweet/presentation/detail/ReplyThread.kt
+++ b/feature/tweet/presentation/src/commonMain/kotlin/com/example/twitturin/feature/tweet/presentation/detail/ReplyThread.kt
@@ -1,0 +1,84 @@
+package com.example.twitturin.feature.tweet.presentation.detail
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.example.chatthread.ThreadComment
+import com.example.chatthread.ThreadStyle
+import com.example.twitturin.core.designsystem.theme.AvatarGradients
+import com.example.twitturin.core.designsystem.theme.Hint
+import com.example.twitturin.core.designsystem.theme.OnBrand
+import com.example.twitturin.core.designsystem.theme.SecondaryText
+import com.example.twitturin.feature.tweet.presentation.ReplyUi
+
+/**
+ * Bridges the reply tree to the vendored CollapsibleChatThread library (:core:chat-thread).
+ * [ThreadComment.id] is the backend reply id, so thread expansion state and reply targeting
+ * both key off the real resource.
+ */
+internal fun ReplyUi.toThreadComment(): ThreadComment = ThreadComment(
+    id = id,
+    author = authorName,
+    avatarBackground = avatarColorFor(authorName),
+    timestamp = date,
+    body = content,
+    avatarInitial = authorName.trim().firstOrNull()?.uppercaseChar()?.toString() ?: "?",
+    channel = if (authorUsername.isBlank()) null else "@$authorUsername",
+    replies = replies.map { it.toThreadComment() },
+)
+
+/** Every reply id that has children — used to open the whole tree once replies load. */
+internal fun collectExpandableIds(replies: List<ReplyUi>): Set<String> {
+    val ids = mutableSetOf<String>()
+    fun walk(nodes: List<ReplyUi>) {
+        nodes.forEach { node ->
+            if (node.replies.isNotEmpty()) {
+                ids.add(node.id)
+                walk(node.replies)
+            }
+        }
+    }
+    walk(replies)
+    return ids
+}
+
+/** Flattens the tree into an id-indexed map so a tapped [ThreadComment] maps back to its [ReplyUi]. */
+internal fun indexRepliesById(replies: List<ReplyUi>): Map<String, ReplyUi> {
+    val index = mutableMapOf<String, ReplyUi>()
+    fun walk(nodes: List<ReplyUi>) {
+        nodes.forEach { node ->
+            index[node.id] = node
+            walk(node.replies)
+        }
+    }
+    walk(replies)
+    return index
+}
+
+/** Solid avatar color: the first stop of the same gradient GradientAvatar picks for this seed. */
+private fun avatarColorFor(seed: String): Color {
+    val idx = if (seed.isEmpty()) 0 else (seed.sumOf { it.code } % AvatarGradients.size)
+    return AvatarGradients[idx].first()
+}
+
+/** [ThreadStyle] re-skinned with the TwitturIn design system (DM Sans type + brand palette). */
+@Composable
+internal fun twitturThreadStyle(): ThreadStyle = ThreadStyle.Default.copy(
+    avatarSize = 32.dp,
+    avatarContentColor = OnBrand,
+    connectorColor = Hint.copy(alpha = 0.5f),
+    connectorStrokeWidth = 1.5.dp,
+    connectorCornerRadius = 10.dp,
+    indentPerLevel = 24.dp,
+    rowVerticalSpacing = 14.dp,
+    primaryTextColor = MaterialTheme.colorScheme.onBackground,
+    secondaryTextColor = SecondaryText,
+    authorStyle = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.Bold),
+    timestampStyle = MaterialTheme.typography.bodySmall,
+    channelStyle = MaterialTheme.typography.bodySmall,
+    bodyStyle = MaterialTheme.typography.bodyMedium,
+    actionStyle = MaterialTheme.typography.bodySmall.copy(fontWeight = FontWeight.Medium),
+    avatarTextStyle = MaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.Bold),
+)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -53,6 +53,8 @@ include(":core:domain")
 include(":core:data")
 include(":core:presentation")
 include(":core:design-system")
+// :core:chat-thread — vendored CollapsibleChatThread lib (threaded replies UI); see its README.
+include(":core:chat-thread")
 // :feature:search — pilot vertical slice (Track A). Layers added as each is built.
 include(":feature:search:domain")
 include(":feature:search:data")


### PR DESCRIPTION
## What

Adds fully threaded (nested) replies to the tweet detail screen, built on my [chat_thread_lib](https://github.com/extractive-mana-pulse/chat_thread_lib) vendored as **`:core:chat-thread`**.

- **`:core:chat-thread`** — the CollapsibleChatThread library compiled as commonMain (Android + iOS + Desktop): recursive `ThreadComment` tree, flattener with expansion state (`rememberThreadState`), indent-aware connector lines, expand/collapse + reply chips per row. Upstream's JitPack artifact is an Android-only AAR, so the pure-Compose source is vendored (see the module README).
- **Detail screen** — replies render as a collapsible tree instead of a flat list; the whole tree auto-expands when a fresh reply set loads. Tapping a row's **Reply** chip aims the composer at that reply (a "Replying to @user" chip appears above the input; dismissable).
- **Nested replies API** — `TweetRepository.postReplyToReply` posts `POST replies/{id}` (reply-to-reply), alongside the existing `POST tweets/{id}/replies` for top-level replies. Reply DTOs tolerate the reply-shaped payload (covered by `ReplyDtoTest`).
- Thread styling maps the TwitturIn design system onto the library's `ThreadStyle` (DM Sans type ramp, brand connector colours, gradient-avatar colour seeds).

## Verification
- `./gradlew :androidApp:assembleDebug` ✅
- `./gradlew :composeApp:compileKotlinJvm` ✅
- `./gradlew :composeApp:linkDebugFrameworkIosSimulatorArm64` ✅
- `:core:chat-thread:jvmTest` (ThreadFlattener) + `:feature:tweet:data:jvmTest` (ReplyDto) ✅

## Merge order
Part of a linear stack: this PR → `feature/compose-multiplatform`, then #6 (rich text) on top of this branch, then the migration branch → `main`. Merge this one **first**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)